### PR TITLE
Fix back office error for non-administrator users (editors...)

### DIFF
--- a/includes/classes/admin/pages/class-admin-main.php
+++ b/includes/classes/admin/pages/class-admin-main.php
@@ -85,6 +85,11 @@ class Admin_Main extends Module {
 	 */
 	public function override_first_menu_name() {
 		global $submenu;
+
+		if ( !isset($submenu['axeptio-wordpress-plugin']) ) {
+			return;
+		}
+
 		$submenu['axeptio-wordpress-plugin'][0][0] = __( 'Settings', 'axeptio-wordpress-plugin' ); // PHPCS:Ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 


### PR DESCRIPTION
If you are a user with a role that does not have permissions to see the "Axeptio" tab in the back office, then you will have an "Undefined array key 2" error.