### PR TITLE
Alpine.js conflict with other plugin solve

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -179,6 +179,10 @@ function style_url( $stylesheet, $context ) {
  * @return void
  */
 function admin_scripts() {
+	$screen = get_current_screen();
+	if ( 'toplevel_page_axeptio-wordpress-plugin' != $screen->id ) {
+		return;
+	}
 	wp_enqueue_media();
 	wp_enqueue_script(
 		'axeptio/main',


### PR DESCRIPTION
You guys are compiling Alpinejs with your app.js and enqueueing this app.js globally withing the WordPress admin which is causing Alpinejs conflict with other plugins. I just solved this and here is the PR. I hope, you will take a look at that and will take a necessary steps.