### PR TITLE
fix: prevent null pointer error in get_plugin() for PHP 8.0+

### DIFF
--- a/includes/classes/utils/class-search-callback-file-location.php
+++ b/includes/classes/utils/class-search-callback-file-location.php
@@ -41,7 +41,7 @@ class Search_Callback_File_Location {
      */
     public static function get_plugin( $callback_function, ?string $name = null, ?string $filter = null, ?int $priority = null ): ?string {
         $filename = self::find_filename( $callback_function, $name, $filter, $priority );
-		return self::extract_plugin_name($filename);
+		return !is_null($filename) ? self::extract_plugin_name($filename) : null;
     }
 
 	/**


### PR DESCRIPTION
## 🐛 Fix: PHP 8.0+ compatibility issue in Search_Callback_File_Location

### 📋 **Description**
Fixed a null pointer issue in `Search_Callback_File_Location::get_plugin()` that was causing errors in PHP 8.0+ when processing WordPress core callbacks.

### 🔍 **Root Cause Analysis**
- **Issue**: `$filename` can be `null` when callbacks originate from WordPress core
- **Impact**: PHP 8.0+ strict typing causes parsing errors when passing `null` to `extract_plugin_name()`
- **Detection**: Identified via xdebug analysis showing null values in core WP filter processing

### 🛠️ **Solution**
Added null check before calling `extract_plugin_name()`:
```php
return !is_null($filename) ? self::extract_plugin_name($filename) : null;
```

### 📝 **How to Reproduce**
1. **Environment**: PHP 8.0+ (tested on 8.0, 8.1, 8.2)
2. **Steps**:
   - Install WordPress with core filters active
   - Trigger callback analysis on core WordPress hooks
   - Observe error when `get_plugin()` processes core callbacks
3. **Expected behavior**: Should return `null` gracefully for core callbacks
4. **Previous behavior**: Fatal error due to null being passed to string manipulation

### 🔧 **Technical Details**
The issue occurs in the call chain:
get_plugin() → find_filename()

When `find_filename()` returns `null` (legitimate for WP core callbacks), `extract_plugin_name()` was receiving `null` instead of a string, causing `wp_normalize_path()` to fail in PHP 8.0+.

**Before:**
```php
return self::extract_plugin_name($filename); // $filename can be null
```

**After:**
```php
return !is_null($filename) ? self::extract_plugin_name($filename) : null;
```

@ogorzalka Can you confirm that this will not have an impact on the modification of filters/shortcodes configured in BO?