### PR TITLE
feat: PLG-129 - authorize Axeptio on WordPress version 6.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   Axeptio WordPress Plugin
 </h1>
 
-![Version](https://img.shields.io/badge/version-1.0.0-blue?style=flat-square) ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square) ![WordPress Version](https://img.shields.io/badge/WordPress-%5E5.0-blue?style=flat-square) ![PHP Version](https://img.shields.io/badge/PHP-%3E%3D%207.4-blue?style=flat-square)
+![Version](https://img.shields.io/badge/version-2.6.2-blue?style=flat-square) ![License](https://img.shields.io/badge/license-MIT-green?style=flat-square) ![WordPress Version](https://img.shields.io/badge/WordPress-%5E5.0-blue?style=flat-square) ![PHP Version](https://img.shields.io/badge/PHP-%3E%3D%207.4-blue?style=flat-square)
 
 Integrate the Axeptio SDK with your WordPress Website for seamless privacy management.
 

--- a/axeptio-wordpress-plugin.php
+++ b/axeptio-wordpress-plugin.php
@@ -3,7 +3,7 @@
 	Plugin Name: Axeptio
 	Plugin URI: https://www.axeptio.eu/
 	Description: Axeptio allows you to make your website compliant with GDPR.
-	Version: 2.6.1
+	Version: 2.6.2
 	Author: axeptio
 	License: GPLv3
 	License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/axeptio-wordpress-plugin.php
+++ b/axeptio-wordpress-plugin.php
@@ -12,7 +12,7 @@
 	Requires Plugins: wp-consent-api
  **/
 
-define( 'XPWP_VERSION', '2.6.1' );
+define( 'XPWP_VERSION', '2.6.2' );
 define( 'XPWP_URL', plugin_dir_url( __FILE__ ) );
 define( 'XPWP_PATH', plugin_dir_path( __FILE__ ) );
 define( 'XPWP_BASENAME', plugin_basename( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Axeptio
 Tags: Axeptio, GDPR, RGPD, Cookies, Consent
 Requires at least: 5.0
-Tested up to: 6.8.2
+Tested up to: 6.9
 Stable tag: 2.6.2
 Requires PHP: 7.4
 License: GPLv3


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Declare compatibility with WordPress 6.9 and bump the plugin to version 2.6.2. Updates readme fields and badges to reflect the new version and tested WP target.

<sup>Written for commit 5866bd91acdb63b1bc6fa88103b3c8dced72428c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



