### PR TITLE
chore: add .mcp.json and document Redmine MCP setup in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ dwsync.xml
 .internal
 bin/act
 .env
+

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "redmine": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "mcp-redmine==2026.01.13.152335",
+        "--refresh-package",
+        "mcp-redmine",
+        "mcp-redmine"
+      ],
+      "env": {
+        "REDMINE_URL": "${REDMINE_URL}",
+        "REDMINE_API_KEY": "${REDMINE_API_KEY}",
+        "REDMINE_ALLOWED_DIRECTORIES": "/tmp/redmine-uploads"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -108,6 +108,45 @@ For detailed setup, configuration, and troubleshooting, please read our full [Do
 - [Coding Standards](http://codex.wordpress.org/WordPress_Coding_Standards)
 - [Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/).
 
+## Claude Code MCP Setup (Redmine)
+
+The repository ships with a `.mcp.json` that registers the [mcp-redmine](https://pypi.org/project/mcp-redmine/) server for use with Claude Code.
+
+### Prerequisites
+
+Add the following variables to your shell profile (e.g. `~/.zshrc`):
+
+```bash
+export REDMINE_URL="https://projets.adexos.fr/"
+export REDMINE_API_KEY="<your-redmine-api-key>"
+```
+
+Create the upload scratch directory once:
+
+```bash
+mkdir -p /tmp/redmine-uploads
+```
+
+### How it works
+
+`.mcp.json` passes `${REDMINE_URL}` and `${REDMINE_API_KEY}` as env var references — they are expanded from your shell environment when Claude Code starts. No secrets are stored in the file.
+
+The server is launched via `uvx` (part of the `uv` Python toolchain). If `uvx` is not installed:
+
+```bash
+brew install uv
+```
+
+### Verification
+
+After starting Claude Code from this directory:
+
+```bash
+claude mcp list | grep redmine
+```
+
+Expected output: `redmine: uvx ... - ✓ Connected`
+
 ## Contributions
 
 ### Commit


### PR DESCRIPTION
## Summary
- Adds `.mcp.json` registering the Redmine MCP server for Claude Code
- Documents setup in README (matching the shopify-app-remix repo format): prerequisites, how it works, verification steps

## Test plan
- [ ] Verify `claude mcp list | grep redmine` shows `✓ Connected` after setting `REDMINE_URL` and `REDMINE_API_KEY`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the Redmine MCP server for Claude Code via .mcp.json and adds setup instructions to the README. Enables Redmine access in Claude Code using environment variables; no secrets stored in the repo.

- **Migration**
  - Export REDMINE_URL and REDMINE_API_KEY in your shell profile.
  - Create /tmp/redmine-uploads (used by REDMINE_ALLOWED_DIRECTORIES).
  - Install uv if uvx is missing (brew install uv).
  - Start Claude Code and run: claude mcp list | grep redmine; expect “✓ Connected”.

<sup>Written for commit d6cdb05a1f969d3ce26ff173398771d76ba1dcc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

