### PR TITLE
docs: add deployment workflow documentation

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -86,5 +86,8 @@ Thumbs.db
 *~
 .env
 
+# Internal engineering documentation
+/docs
+
 # Development README (readme.txt is for WordPress.org)
 README.md

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "MD013": {
+    "tables": false
+  },
+  "MD060": false
+}

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,15 @@
+# Deployment Documentation
+
+Overview of the CI/CD pipeline for the WordPress Plugin (`axeptio-sdk-integration`).
+
+> **Note:** Unlike a server-side application, this plugin has no cloud infrastructure (no AWS, ECS, Terraform).
+> It is distributed as a PHP/JS package via the [WordPress.org plugin directory](https://wordpress.org/plugins/axeptio-sdk-integration/)
+> using SVN as the distribution channel.
+
+## Table of Contents
+
+| Document                         | Description                                       |
+| :------------------------------- | :------------------------------------------------ |
+| [Workflows](workflows.md)       | GitHub Actions workflows: triggers, jobs, steps   |
+| [Environments](environments.md) | Local dev setup and WordPress.org release process |
+| [Improvements](improvements.md) | Flagged issues, risks, and improvement proposals  |

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -5,17 +5,17 @@ The WordPress plugin has no cloud infrastructure. The two environments are **loc
 
 ## Environment Matrix
 
-| Property          | Local (Dev)                        | WordPress.org (Production)                        |
-| :---------------- | :--------------------------------- | :------------------------------------------------ |
-| Branch            | Any (local)                        | Git tag pushed to GitHub                          |
-| Trigger           | Manual (`task start` / `yarn watch`) | Automated on git tag via `deploy.yml`           |
-| PHP version       | 7.4 (Docker)                       | 7.4 (CI — see [Improvements #3](improvements.md)) |
-| Node version      | 18 (volta pin)                     | 16 (CI — see [Improvements #2](improvements.md))  |
-| JS build          | `yarn start` (watch) / `yarn build` | `yarn build:production`                          |
-| Composer          | `composer install` (with dev)      | `composer install --no-dev --optimize-autoloader` |
-| Distribution      | Local filesystem                   | WordPress.org SVN + GitHub release `.zip`         |
-| SVN path          | -                                  | `trunk/` (latest) + `tags/<version>/`             |
-| Store assets      | -                                  | `release-assets/` → SVN `assets/`                |
+| Property          | Local (Dev)                          | WordPress.org (Production)                                 |
+| :---------------- | :----------------------------------- | :--------------------------------------------------------- |
+| Branch            | Any (local)                          | Git tag pushed to GitHub                                   |
+| Trigger           | Manual (`task start` / `yarn watch`) | Git tag push (automated) or `workflow_dispatch` (manual)   |
+| PHP version       | 7.4 (Docker)                         | 7.4 (CI — see [Improvements #3](improvements.md))          |
+| Node version      | 18 (Volta pin)                       | 18 (CI)                                                    |
+| JS build          | `yarn start` (watch) / `yarn build`  | `yarn build:production`                                    |
+| Composer          | `composer install` (with dev)        | `composer install --no-dev --optimize-autoloader`          |
+| Distribution      | Local filesystem                     | WordPress.org SVN + GitHub release `.zip`                  |
+| SVN path          | -                                    | `trunk/` (latest) + `tags/<version>/`                      |
+| Store assets      | -                                    | `release-assets/` → SVN `assets/`                          |
 
 ## Local Development Setup
 
@@ -58,36 +58,44 @@ It is **not** used in GitHub Actions CI.
 sequenceDiagram
     participant Dev as Developer
     participant GH as GitHub
-    participant CI as GitHub Actions
+    participant LA as lint-and-test job
+    participant DJ as deploy job
     participant WPSVN as WordPress.org SVN
     participant GHR as GitHub Releases
 
-    Dev->>GH: git tag vX.Y.Z && git push --tags
-    GH->>CI: Trigger deploy.yml
-    CI->>CI: Lint (ESLint + PHPCS)
-    CI->>CI: Test (Pest)
-    CI->>CI: Build (JS prod + Composer no-dev)
-    CI->>CI: rsync → ./tmp/ (using exclusions.txt)
-    CI->>WPSVN: Deploy trunk/ + tags/X.Y.Z/ + assets/
-    CI->>CI: Generate axeptio-wordpress-plugin.zip
-    CI->>GHR: Create release with .zip attached
+    Dev->>GH: git tag X.Y.Z && git push --tags
+    GH->>LA: Trigger deploy.yml (lint-and-test job)
+    LA->>LA: Lint (ESLint + PHPCS)
+    LA->>LA: Test (composer test)
+    LA->>DJ: passed (needs:)
+    DJ->>DJ: Build (yarn build:production + composer install --no-dev)
+    DJ->>WPSVN: 10up action: deploy trunk/ + tags/X.Y.Z/ + assets/ (via .distignore)
+    DJ->>DJ: Generate .zip artifact
+    DJ->>GHR: Create release with .zip attached
 ```
 
 ### What gets deployed to SVN
 
-The `exclusions.txt` file controls which files are **excluded** from the release package.
-Key excluded paths:
+Two files control which paths are excluded from the release package, depending on how the release is triggered:
 
-| Excluded path      | Reason                                |
-| :----------------- | :------------------------------------ |
-| `assets/`          | Raw source assets (compiled to `public/`) |
-| `node_modules/`    | JS dependencies                       |
-| `docs/`            | Internal engineering documentation    |
-| `release-assets/`  | Moved to SVN `assets/` separately     |
-| `releases/`        | Temporary SVN checkout directory      |
-| `tmp/`             | Temporary build output                |
-| `.git/`, `.github/` | VCS and CI config                    |
-| Dev config files   | `phpcs.xml`, `phpstan.neon.dist`, etc. |
+| File              | Used by                        | Has inline comments |
+| :---------------- | :----------------------------- | :------------------ |
+| `.distignore`     | CI pipeline (`deploy.yml`)     | Yes                 |
+| `exclusions.txt`  | Manual `task release` command  | No                  |
+
+Both files must be kept in sync. See [Improvements](improvements.md) for known gaps.
+
+Key paths excluded from the release package:
+
+| Excluded path       | Reason                                          |
+| :------------------ | :---------------------------------------------- |
+| `assets/`           | Raw source assets (compiled output is in `dist/`) |
+| `node_modules/`     | JS dependencies                                 |
+| `release-assets/`   | Moved to SVN `assets/` separately               |
+| `releases/`         | Temporary SVN checkout directory                |
+| `tmp/`              | Temporary build output                          |
+| `.git/`, `.github/` | VCS and CI config                               |
+| Dev config files    | `phpcs.xml`, `phpstan.neon.dist`, etc.          |
 
 ### SVN Structure on WordPress.org
 

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -43,14 +43,14 @@ It is **not** used in GitHub Actions CI.
 
 **Common local commands (via Taskfile):**
 
-| Task                  | Command           | Description                              |
-| :-------------------- | :---------------- | :--------------------------------------- |
-| `task build`          | docker-compose up | Build and start containers               |
-| `task composer-install` | composer install | Install PHP dependencies in container   |
-| `task lint-php`       | composer run phpcs | Run PHPCS in container                  |
-| `task php-stan`       | composer run-stan | Run PHPStan static analysis             |
-| `task ssh`            | docker-compose run | Open shell in container                 |
-| `task stop`           | docker-compose down | Stop containers                        |
+| Task                    | Command                  | Description                              |
+| :---------------------- | :----------------------- | :--------------------------------------- |
+| `task build`            | docker-compose up        | Build and start containers               |
+| `task composer-install` | composer install         | Install PHP dependencies in container   |
+| `task lint-php`         | composer run phpcs       | Run PHPCS in container                   |
+| `task php-stan`         | composer run run-stan    | Run PHPStan static analysis              |
+| `task ssh`              | docker-compose run       | Open shell in container                  |
+| `task stop`             | docker-compose down      | Stop containers                          |
 
 ## WordPress.org Release Process
 
@@ -82,6 +82,7 @@ Key excluded paths:
 | :----------------- | :------------------------------------ |
 | `assets/`          | Raw source assets (compiled to `public/`) |
 | `node_modules/`    | JS dependencies                       |
+| `docs/`            | Internal engineering documentation    |
 | `release-assets/`  | Moved to SVN `assets/` separately     |
 | `releases/`        | Temporary SVN checkout directory      |
 | `tmp/`             | Temporary build output                |

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -1,0 +1,115 @@
+# Environments
+
+The WordPress plugin has no cloud infrastructure. The two environments are **local development** and
+**WordPress.org** (the public plugin directory).
+
+## Environment Matrix
+
+| Property          | Local (Dev)                        | WordPress.org (Production)                        |
+| :---------------- | :--------------------------------- | :------------------------------------------------ |
+| Branch            | Any (local)                        | Git tag pushed to GitHub                          |
+| Trigger           | Manual (`task start` / `yarn watch`) | Automated on git tag via `deploy.yml`           |
+| PHP version       | 7.4 (Docker)                       | 7.4 (CI — see [Improvements #3](improvements.md)) |
+| Node version      | 18 (volta pin)                     | 16 (CI — see [Improvements #2](improvements.md))  |
+| JS build          | `yarn start` (watch) / `yarn build` | `yarn build:production`                          |
+| Composer          | `composer install` (with dev)      | `composer install --no-dev --optimize-autoloader` |
+| Distribution      | Local filesystem                   | WordPress.org SVN + GitHub release `.zip`         |
+| SVN path          | -                                  | `trunk/` (latest) + `tags/<version>/`             |
+| Store assets      | -                                  | `release-assets/` → SVN `assets/`                |
+
+## Local Development Setup
+
+```mermaid
+graph LR
+    A[Clone repo] --> B[task build]
+    B --> C[Docker up — PHP 7.4 Alpine]
+    C --> D[task composer-install]
+    D --> E[yarn install]
+    E --> F[yarn start — webpack watch]
+```
+
+### Docker Environment
+
+The Docker setup is **for local PHP tooling only** (Composer, PHPCS, PHPStan, Pest).
+It is **not** used in GitHub Actions CI.
+
+| Setting              | Value                          |
+| :------------------- | :----------------------------- |
+| Base image           | `php:7.4-alpine`               |
+| PHP extensions       | `bcmath`, `calendar`, `sockets` |
+| Composer             | v2 (installed at image build)  |
+| Working directory    | `/var/www/html/`               |
+| Volume               | `.:/var/www/html` (live mount) |
+
+**Common local commands (via Taskfile):**
+
+| Task                  | Command           | Description                              |
+| :-------------------- | :---------------- | :--------------------------------------- |
+| `task build`          | docker-compose up | Build and start containers               |
+| `task composer-install` | composer install | Install PHP dependencies in container   |
+| `task lint-php`       | composer run phpcs | Run PHPCS in container                  |
+| `task php-stan`       | composer run-stan | Run PHPStan static analysis             |
+| `task ssh`            | docker-compose run | Open shell in container                 |
+| `task stop`           | docker-compose down | Stop containers                        |
+
+## WordPress.org Release Process
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant GH as GitHub
+    participant CI as GitHub Actions
+    participant WPSVN as WordPress.org SVN
+    participant GHR as GitHub Releases
+
+    Dev->>GH: git tag vX.Y.Z && git push --tags
+    GH->>CI: Trigger deploy.yml
+    CI->>CI: Lint (ESLint + PHPCS)
+    CI->>CI: Test (Pest)
+    CI->>CI: Build (JS prod + Composer no-dev)
+    CI->>CI: rsync → ./tmp/ (using exclusions.txt)
+    CI->>WPSVN: Deploy trunk/ + tags/X.Y.Z/ + assets/
+    CI->>CI: Generate axeptio-wordpress-plugin.zip
+    CI->>GHR: Create release with .zip attached
+```
+
+### What gets deployed to SVN
+
+The `exclusions.txt` file controls which files are **excluded** from the release package.
+Key excluded paths:
+
+| Excluded path      | Reason                                |
+| :----------------- | :------------------------------------ |
+| `assets/`          | Raw source assets (compiled to `public/`) |
+| `node_modules/`    | JS dependencies                       |
+| `release-assets/`  | Moved to SVN `assets/` separately     |
+| `releases/`        | Temporary SVN checkout directory      |
+| `tmp/`             | Temporary build output                |
+| `.git/`, `.github/` | VCS and CI config                    |
+| Dev config files   | `phpcs.xml`, `phpstan.neon.dist`, etc. |
+
+### SVN Structure on WordPress.org
+
+```text
+https://plugins.svn.wordpress.org/axeptio-sdk-integration/
+  trunk/          ← Latest release (overwritten on each deploy)
+  tags/
+    2.1/
+    2.2/
+    2.3/
+    X.Y.Z/        ← New tag created on each deploy
+  assets/         ← Banners, icons, screenshots (from release-assets/)
+```
+
+### Rollback Strategy
+
+WordPress.org does not support rollback via pipeline. To roll back:
+
+1. **For users:** WordPress.org retains all previous tagged versions. Users can install a previous version manually.
+2. **For SVN trunk:** Revert `trunk/` to a previous tag by re-deploying from a known-good git tag:
+   - Push the previous git tag again (or create a new patch tag from the old commit)
+   - The pipeline will overwrite `trunk/` with the previous version
+3. **GitHub release:** Delete the incorrect release on GitHub and re-run from the correct tag.
+
+> **Warning:** There is no staging environment for WordPress.org. Every tagged release is immediately public.
+> Test thoroughly in the local environment before tagging.

--- a/docs/deployment/improvements.md
+++ b/docs/deployment/improvements.md
@@ -36,3 +36,9 @@ Issues, risks, and proposals identified during the deployment workflow review.
 | 13 | Workflow | Taskfile `release` task duplicates GitHub Action SVN logic — risk of manual bypasses | Clarify it is for emergency use only; consider renaming to `release:manual` |
 | 14 | Workflow | `exclusions.txt` has no comments explaining why each path is excluded         | Add inline comments or reference this document                                  |
 | 15 | Workflow | `composer install` in CI missing `--no-interaction` flag                      | Add `--no-interaction` and `--prefer-dist` to all `composer install` CI steps   |
+
+## Fixed in this PR
+
+| #  | Area      | Issue                                                                         | Fix                                                                             |
+| :- | :-------- | :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 16 | Packaging | `docs/` directory was not in `exclusions.txt` — internal engineering docs would be shipped in the WordPress.org SVN package and end-user `.zip` | Added `docs/` to `exclusions.txt`                                |

--- a/docs/deployment/improvements.md
+++ b/docs/deployment/improvements.md
@@ -1,0 +1,55 @@
+# Improvements
+
+Issues, risks, and proposals identified during the deployment workflow review.
+
+## Critical
+
+| #   | Area     | Issue                                             | Impact                                                      |
+| :-- | :------- | :------------------------------------------------ | :---------------------------------------------------------- |
+| 1   | Workflow | No CI on PRs or `develop` branch. Tests and linting | Regressions can be merged undetected. Issues are only      |
+|     |          | only run at tag push (release time).              | caught at release time, too late to revert cleanly.         |
+| 2   | Workflow | Node.js version mismatch: CI uses Node 16,        | Builds may behave differently locally vs CI. Node 16 is EOL |
+|     |          | `.nvmrc` and `volta` pin Node 18.                 | since Sept 2023.                                            |
+
+## High
+
+| #   | Area     | Issue                                             | Recommendation                                              |
+| :-- | :------- | :------------------------------------------------ | :---------------------------------------------------------- |
+| 3   | Workflow | PHP version mismatch: CI uses PHP 7.4 only, but  | Add a matrix build testing PHP 7.4 and 8.0/8.1 to match    |
+|     |          | `composer.json` declares `^7.4 \|\| ^8.0`.       | the declared support range.                                 |
+| 4   | Workflow | Outdated GitHub Actions: `actions/checkout@v2`,   | Upgrade to `@v4` for checkout and setup-node,              |
+|     |          | `actions/setup-node@v2`, `shivammathur/setup-php@v2` | `shivammathur/setup-php@v2` is current but verify SHA.  |
+| 5   | Workflow | `.gitlab-ci.yml` still present after migration to | Remove the file. It is not executed by GitHub Actions and   |
+|     |          | GitHub Actions. Only ran PHPCS and ESLint.        | misleads contributors about active CI pipelines.            |
+| 6   | Workflow | Single job for all steps (lint → test → build →   | Split into separate jobs: `lint`, `test`, `build`, `deploy` |
+|     |          | deploy). No parallelization or independent        | with `needs:` dependencies. Speeds up feedback and allows   |
+|     |          | failure stages.                                   | re-running only failed stages.                              |
+
+## Medium
+
+| #   | Area     | Issue                                             | Recommendation                                              |
+| :-- | :------- | :------------------------------------------------ | :---------------------------------------------------------- |
+| 7   | Security | `10up/action-wordpress-plugin-deploy@stable` not  | Pin to a specific version tag or commit SHA for supply      |
+|     |          | pinned to a version or SHA.                       | chain security.                                             |
+| 8   | Security | `softprops/action-gh-release@v1` not pinned to    | Pin to a commit SHA.                                        |
+|     |          | a SHA.                                            |                                                             |
+| 9   | Workflow | `yarn install` without `--frozen-lockfile`. Could | Use `yarn install --frozen-lockfile` in CI to ensure        |
+|     |          | silently upgrade packages.                        | reproducible installs.                                      |
+| 10  | Workflow | `vendor/bin/pest` hardcoded instead of            | Use `composer run test` to stay consistent with             |
+|     |          | `composer run test`.                              | `composer.json` scripts.                                    |
+| 11  | Workflow | No deployment dry-run capability. Every tag push  | Add a manual `workflow_dispatch` trigger that runs          |
+|     |          | goes directly to WordPress.org.                   | lint/test/build but skips SVN deploy.                       |
+| 12  | Security | SVN credentials (`SVN_USERNAME`, `SVN_PASSWORD`)  | Document a secret rotation policy and ensure secrets are    |
+|     |          | have no documented rotation policy.               | scoped to the minimum required permissions.                 |
+
+## Low
+
+| #   | Area     | Issue                                             | Recommendation                                              |
+| :-- | :------- | :------------------------------------------------ | :---------------------------------------------------------- |
+| 13  | Workflow | Taskfile.yml `release` task duplicates the SVN    | Clarify in documentation that the Taskfile task is for      |
+|     |          | deploy logic of the GitHub Action. Risk of manual | manual emergency use only. Consider removing or renaming    |
+|     |          | SVN pushes bypassing CI checks.                   | to `release:manual`.                                        |
+| 14  | Workflow | `exclusions.txt` not documented. Unclear which    | Add inline comments to `exclusions.txt` or reference it    |
+|     |          | files are excluded from the SVN package and why.  | in this documentation.                                      |
+| 15  | Workflow | `composer install` in CI has no `--no-interaction` | Add `--no-interaction` and `--prefer-dist` flags to         |
+|     |          | flag. May prompt or behave unexpectedly.          | `composer install` in CI steps.                             |

--- a/docs/deployment/improvements.md
+++ b/docs/deployment/improvements.md
@@ -4,41 +4,57 @@ Issues, risks, and proposals identified during the deployment workflow review.
 
 ## Critical
 
-| #  | Area     | Issue                                                                         | Impact                                                                          |
-| :- | :------- | :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 1  | Workflow | No CI on PRs or `develop` — tests and linting only run at tag push            | Regressions merge undetected; issues caught at release time, too late to revert |
-| 2  | Workflow | Node.js version mismatch: CI uses Node 16, `.nvmrc` and `volta` pin Node 18   | Builds differ locally vs CI; Node 16 is EOL since Sept 2023                     |
+| #  | Area     | Issue                                                                                   | Impact                                                                          |
+| :- | :------- | :-------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 1  | Workflow | No CI on PRs or `develop` — tests and linting only run at tag push                     | Regressions merge undetected; issues caught at release time, too late to revert |
 
 ## High
 
-| #  | Area     | Issue                                                                         | Recommendation                                                                  |
-| :- | :------- | :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 3  | Workflow | PHP version mismatch: CI uses PHP 7.4 only, `composer.json` supports `^7.4 \|\| ^8.0` | Add a matrix build testing PHP 7.4 and 8.x to match declared support range |
-| 4  | Workflow | Outdated GitHub Actions: `actions/checkout@v2`, `actions/setup-node@v2`       | Upgrade to `@v4` for checkout and setup-node; verify `setup-php` SHA           |
-| 5  | Workflow | `.gitlab-ci.yml` still present after migration to GitHub Actions               | Remove the file — it is no longer active and misleads contributors              |
-| 6  | Workflow | Single job for all steps (lint → test → build → deploy), no parallelization   | Split into `lint`, `test`, `build`, `deploy` jobs with `needs:` dependencies   |
+| #  | Area     | Issue                                                                                   | Recommendation                                                                  |
+| :- | :------- | :-------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 3  | Workflow | PHP version mismatch: CI uses PHP 7.4 only; `composer.json` supports `^7.4 \|\| ^8.0` | Add a matrix build testing PHP 7.4 and 8.x to match declared support range      |
+| 5  | Workflow | `.gitlab-ci.yml` still present after migration to GitHub Actions                       | Remove the file; it is no longer active and misleads contributors               |
 
 ## Medium
 
-| #  | Area     | Issue                                                                         | Recommendation                                                                  |
-| :- | :------- | :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 7  | Security | `10up/action-wordpress-plugin-deploy@stable` not pinned to version or SHA     | Pin to a specific version tag or commit SHA for supply chain security           |
-| 8  | Security | `softprops/action-gh-release@v1` not pinned to a SHA                         | Pin to a commit SHA                                                             |
-| 9  | Workflow | `yarn install` without `--frozen-lockfile` — may silently upgrade packages    | Use `yarn install --frozen-lockfile` in CI for reproducible installs            |
-| 10 | Workflow | `vendor/bin/pest` hardcoded instead of `composer run test`                    | Use `composer run test` to stay consistent with `composer.json` scripts         |
-| 11 | Workflow | No dry-run capability — every tag push deploys directly to WordPress.org      | Add a `workflow_dispatch` trigger that runs lint/test/build but skips SVN deploy |
-| 12 | Security | SVN credentials (`SVN_USERNAME`, `SVN_PASSWORD`) have no rotation policy      | Document a rotation policy; scope secrets to minimum required permissions       |
+| #  | Area     | Issue                                                                                   | Recommendation                                                                  |
+| :- | :------- | :-------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 12 | Security | SVN credentials (`SVN_USERNAME`, `SVN_PASSWORD`) have no rotation policy                | Document a rotation policy; scope secrets to minimum required permissions       |
+| 13 | Workflow | Taskfile `release` task duplicates GitHub Action SVN logic — risk of manual bypasses   | Clarify it is for emergency use only; consider renaming to `release:manual`     |
 
 ## Low
 
-| #  | Area     | Issue                                                                         | Recommendation                                                                  |
-| :- | :------- | :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 13 | Workflow | Taskfile `release` task duplicates GitHub Action SVN logic — risk of manual bypasses | Clarify it is for emergency use only; consider renaming to `release:manual` |
-| 14 | Workflow | `exclusions.txt` has no comments explaining why each path is excluded         | Add inline comments or reference this document                                  |
-| 15 | Workflow | `composer install` in CI missing `--no-interaction` flag                      | Add `--no-interaction` and `--prefer-dist` to all `composer install` CI steps   |
+| #  | Area     | Issue                                                                                   | Recommendation                                                                  |
+| :- | :------- | :-------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 14 | Workflow | `exclusions.txt` has no inline comments explaining why each path is excluded            | Add inline comments, or reference this document from the file                   |
 
-## Fixed in this PR
+## New Findings
 
-| #  | Area      | Issue                                                                         | Fix                                                                             |
-| :- | :-------- | :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 16 | Packaging | `docs/` directory was not in `exclusions.txt` — internal engineering docs would be shipped in the WordPress.org SVN package and end-user `.zip` | Added `docs/` to `exclusions.txt`                                |
+Issues identified during the review of the CI/CD rework (PRs #47, #48, #50).
+
+| #  | Area     | Issue                                                                                                                                                                                                                    | Recommendation                                                                                                                                                          |
+| :- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 18 | Workflow | `workflow_dispatch` with `dry_run=false` on a non-tag ref skips the deploy step entirely (condition: `startsWith(github.ref, 'refs/tags/') \|\| inputs.dry_run`); the `version` input is still required but unused in that case | Document that `workflow_dispatch` is intended for dry-run testing only; consider removing `dry_run=false` as a supported option or clarifying its purpose in the workflow |
+
+## Fixed in CI/CD Rework (PRs #47, #48, #50)
+
+Resolved by Olivier (ogorzalka).
+
+| #  | Area     | Issue                                                                                   | Fix                                                                             |
+| :- | :------- | :-------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 2  | Workflow | Node.js version mismatch: CI used Node 16; `.nvmrc` and `volta` pin Node 18             | Node 18 now used in CI; Node 16 was EOL since September 2023                   |
+| 4  | Workflow | Outdated GitHub Actions: `checkout@v2`, `setup-node@v2`                                 | Upgraded: `checkout@v4`, `setup-node@v4`, `setup-php@2.37.0`                  |
+| 6  | Workflow | Single job for all steps — no separation between lint, test, build, and deploy          | Split into `lint-and-test` and `deploy` jobs with `needs:` dependency          |
+| 7  | Security | `10up/action-wordpress-plugin-deploy@stable` not pinned to a version or SHA             | Pinned to `@2.3.0`                                                             |
+| 8  | Security | `softprops/action-gh-release@v1` not pinned to a SHA                                   | Pinned to `@v2.2.1`                                                            |
+| 9  | Workflow | `yarn install` without `--frozen-lockfile` — could silently upgrade packages            | Changed to `yarn install --immutable`; fails if lockfile is out of sync        |
+| 10 | Workflow | `vendor/bin/pest` hardcoded instead of `composer run test`                              | Changed to `composer test`                                                     |
+| 11 | Workflow | No dry-run capability — every tag push deployed directly to WordPress.org               | Added `workflow_dispatch` trigger with `dry_run` boolean input (defaults to `true`) |
+| 15 | Workflow | `composer install` in CI missing `--no-interaction` flag                                | Added `--no-interaction --prefer-dist` to all `composer install` CI steps      |
+
+## Fixed in PR #45 and Follow-up
+
+| #  | Area      | Issue                                                                                                                                                                  | Fix                                                          |
+| :- | :-------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------- |
+| 16 | Packaging | `docs/` directory was not in `exclusions.txt` — internal engineering docs would be shipped in the WordPress.org SVN package and end-user `.zip` via the manual release | Added `docs/` to `exclusions.txt` (PR #45)                   |
+| 17 | Packaging | `docs/` directory was not in `.distignore` — internal engineering docs would be shipped in the CI-generated SVN package and end-user `.zip`                           | Added `/docs` to `.distignore`                               |

--- a/docs/deployment/improvements.md
+++ b/docs/deployment/improvements.md
@@ -4,52 +4,35 @@ Issues, risks, and proposals identified during the deployment workflow review.
 
 ## Critical
 
-| #   | Area     | Issue                                             | Impact                                                      |
-| :-- | :------- | :------------------------------------------------ | :---------------------------------------------------------- |
-| 1   | Workflow | No CI on PRs or `develop` branch. Tests and linting | Regressions can be merged undetected. Issues are only      |
-|     |          | only run at tag push (release time).              | caught at release time, too late to revert cleanly.         |
-| 2   | Workflow | Node.js version mismatch: CI uses Node 16,        | Builds may behave differently locally vs CI. Node 16 is EOL |
-|     |          | `.nvmrc` and `volta` pin Node 18.                 | since Sept 2023.                                            |
+| #  | Area     | Issue                                                                         | Impact                                                                          |
+| :- | :------- | :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 1  | Workflow | No CI on PRs or `develop` — tests and linting only run at tag push            | Regressions merge undetected; issues caught at release time, too late to revert |
+| 2  | Workflow | Node.js version mismatch: CI uses Node 16, `.nvmrc` and `volta` pin Node 18   | Builds differ locally vs CI; Node 16 is EOL since Sept 2023                     |
 
 ## High
 
-| #   | Area     | Issue                                             | Recommendation                                              |
-| :-- | :------- | :------------------------------------------------ | :---------------------------------------------------------- |
-| 3   | Workflow | PHP version mismatch: CI uses PHP 7.4 only, but  | Add a matrix build testing PHP 7.4 and 8.0/8.1 to match    |
-|     |          | `composer.json` declares `^7.4 \|\| ^8.0`.       | the declared support range.                                 |
-| 4   | Workflow | Outdated GitHub Actions: `actions/checkout@v2`,   | Upgrade to `@v4` for checkout and setup-node,              |
-|     |          | `actions/setup-node@v2`, `shivammathur/setup-php@v2` | `shivammathur/setup-php@v2` is current but verify SHA.  |
-| 5   | Workflow | `.gitlab-ci.yml` still present after migration to | Remove the file. It is not executed by GitHub Actions and   |
-|     |          | GitHub Actions. Only ran PHPCS and ESLint.        | misleads contributors about active CI pipelines.            |
-| 6   | Workflow | Single job for all steps (lint → test → build →   | Split into separate jobs: `lint`, `test`, `build`, `deploy` |
-|     |          | deploy). No parallelization or independent        | with `needs:` dependencies. Speeds up feedback and allows   |
-|     |          | failure stages.                                   | re-running only failed stages.                              |
+| #  | Area     | Issue                                                                         | Recommendation                                                                  |
+| :- | :------- | :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 3  | Workflow | PHP version mismatch: CI uses PHP 7.4 only, `composer.json` supports `^7.4 \|\| ^8.0` | Add a matrix build testing PHP 7.4 and 8.x to match declared support range |
+| 4  | Workflow | Outdated GitHub Actions: `actions/checkout@v2`, `actions/setup-node@v2`       | Upgrade to `@v4` for checkout and setup-node; verify `setup-php` SHA           |
+| 5  | Workflow | `.gitlab-ci.yml` still present after migration to GitHub Actions               | Remove the file — it is no longer active and misleads contributors              |
+| 6  | Workflow | Single job for all steps (lint → test → build → deploy), no parallelization   | Split into `lint`, `test`, `build`, `deploy` jobs with `needs:` dependencies   |
 
 ## Medium
 
-| #   | Area     | Issue                                             | Recommendation                                              |
-| :-- | :------- | :------------------------------------------------ | :---------------------------------------------------------- |
-| 7   | Security | `10up/action-wordpress-plugin-deploy@stable` not  | Pin to a specific version tag or commit SHA for supply      |
-|     |          | pinned to a version or SHA.                       | chain security.                                             |
-| 8   | Security | `softprops/action-gh-release@v1` not pinned to    | Pin to a commit SHA.                                        |
-|     |          | a SHA.                                            |                                                             |
-| 9   | Workflow | `yarn install` without `--frozen-lockfile`. Could | Use `yarn install --frozen-lockfile` in CI to ensure        |
-|     |          | silently upgrade packages.                        | reproducible installs.                                      |
-| 10  | Workflow | `vendor/bin/pest` hardcoded instead of            | Use `composer run test` to stay consistent with             |
-|     |          | `composer run test`.                              | `composer.json` scripts.                                    |
-| 11  | Workflow | No deployment dry-run capability. Every tag push  | Add a manual `workflow_dispatch` trigger that runs          |
-|     |          | goes directly to WordPress.org.                   | lint/test/build but skips SVN deploy.                       |
-| 12  | Security | SVN credentials (`SVN_USERNAME`, `SVN_PASSWORD`)  | Document a secret rotation policy and ensure secrets are    |
-|     |          | have no documented rotation policy.               | scoped to the minimum required permissions.                 |
+| #  | Area     | Issue                                                                         | Recommendation                                                                  |
+| :- | :------- | :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 7  | Security | `10up/action-wordpress-plugin-deploy@stable` not pinned to version or SHA     | Pin to a specific version tag or commit SHA for supply chain security           |
+| 8  | Security | `softprops/action-gh-release@v1` not pinned to a SHA                         | Pin to a commit SHA                                                             |
+| 9  | Workflow | `yarn install` without `--frozen-lockfile` — may silently upgrade packages    | Use `yarn install --frozen-lockfile` in CI for reproducible installs            |
+| 10 | Workflow | `vendor/bin/pest` hardcoded instead of `composer run test`                    | Use `composer run test` to stay consistent with `composer.json` scripts         |
+| 11 | Workflow | No dry-run capability — every tag push deploys directly to WordPress.org      | Add a `workflow_dispatch` trigger that runs lint/test/build but skips SVN deploy |
+| 12 | Security | SVN credentials (`SVN_USERNAME`, `SVN_PASSWORD`) have no rotation policy      | Document a rotation policy; scope secrets to minimum required permissions       |
 
 ## Low
 
-| #   | Area     | Issue                                             | Recommendation                                              |
-| :-- | :------- | :------------------------------------------------ | :---------------------------------------------------------- |
-| 13  | Workflow | Taskfile.yml `release` task duplicates the SVN    | Clarify in documentation that the Taskfile task is for      |
-|     |          | deploy logic of the GitHub Action. Risk of manual | manual emergency use only. Consider removing or renaming    |
-|     |          | SVN pushes bypassing CI checks.                   | to `release:manual`.                                        |
-| 14  | Workflow | `exclusions.txt` not documented. Unclear which    | Add inline comments to `exclusions.txt` or reference it    |
-|     |          | files are excluded from the SVN package and why.  | in this documentation.                                      |
-| 15  | Workflow | `composer install` in CI has no `--no-interaction` | Add `--no-interaction` and `--prefer-dist` flags to         |
-|     |          | flag. May prompt or behave unexpectedly.          | `composer install` in CI steps.                             |
+| #  | Area     | Issue                                                                         | Recommendation                                                                  |
+| :- | :------- | :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 13 | Workflow | Taskfile `release` task duplicates GitHub Action SVN logic — risk of manual bypasses | Clarify it is for emergency use only; consider renaming to `release:manual` |
+| 14 | Workflow | `exclusions.txt` has no comments explaining why each path is excluded         | Add inline comments or reference this document                                  |
+| 15 | Workflow | `composer install` in CI missing `--no-interaction` flag                      | Add `--no-interaction` and `--prefer-dist` to all `composer install` CI steps   |

--- a/docs/deployment/workflows.md
+++ b/docs/deployment/workflows.md
@@ -43,19 +43,19 @@ sequenceDiagram
 
 **Steps:**
 
-| Step                         | Tool / Command                                                | Notes                                          |
-| :--------------------------- | :------------------------------------------------------------ | :--------------------------------------------- |
-| Checkout code                | `actions/checkout@v2`                                         | Full history                                   |
-| Setup Node.js                | `actions/setup-node@v2` — Node 16                            | See [Improvements #2](improvements.md)         |
+| Step                         | Tool / Command                                                | Notes                                              |
+| :--------------------------- | :------------------------------------------------------------ | :------------------------------------------------- |
+| Checkout code                | `actions/checkout@v2`                                         | Shallow clone (default, `fetch-depth: 1`)          |
+| Setup Node.js                | `actions/setup-node@v2` — Node 16                            | See [Improvements #2](improvements.md)             |
 | Install Node dependencies    | `yarn install`                                                | No `--frozen-lockfile` — see [#9](improvements.md) |
-| ESLint check                 | `yarn eslint`                                                 | Lints `assets/js/`                             |
-| Setup PHP                    | `shivammathur/setup-php@v2` — PHP 7.4                        | See [Improvements #3](improvements.md)         |
-| Install Composer deps        | `composer install`                                            | Includes dev dependencies for tests            |
-| PHPCS check                  | `composer run phpcs`                                          | WordPress Coding Standards                     |
-| Unit tests                   | `vendor/bin/pest`                                             | See [Improvements #10](improvements.md)        |
-| Build                        | `yarn build:production` + `composer install --no-dev` + `rsync` to `./tmp/` | Produces clean release artifact   |
-| WordPress Plugin Deploy      | `10up/action-wordpress-plugin-deploy@stable`                  | SVN deploy to `trunk/` + `tags/<version>/` + zip generation |
-| Create GitHub release        | `softprops/action-gh-release@v1`                              | Attaches `.zip` to the GitHub release          |
+| ESLint check                 | `yarn eslint`                                                 | Lints `assets/js/`                                 |
+| Setup PHP                    | `shivammathur/setup-php@v2` — PHP 7.4                        | See [Improvements #3](improvements.md)             |
+| Install Composer deps        | `composer install`                                            | Includes dev dependencies for tests                |
+| PHPCS check                  | `composer run phpcs`                                          | WordPress Coding Standards                         |
+| Unit tests                   | `vendor/bin/pest`                                             | See [Improvements #10](improvements.md)            |
+| Build                        | `yarn build:production` + `composer install --no-dev` + `rsync` to `./tmp/` | Produces clean release artifact       |
+| WordPress Plugin Deploy      | `10up/action-wordpress-plugin-deploy@stable`                  | SVN deploy to `trunk/` + `tags/<version>/` + zip  |
+| Create GitHub release        | `softprops/action-gh-release@v1`                              | Attaches `.zip` to the GitHub release              |
 
 **Secrets required:**
 

--- a/docs/deployment/workflows.md
+++ b/docs/deployment/workflows.md
@@ -4,10 +4,10 @@ This document describes all CI/CD workflows in `.github/workflows/`.
 
 ## Workflow Inventory
 
-| Workflow              | File                                | Trigger                              | Purpose                              |
-| :-------------------- | :---------------------------------- | :----------------------------------- | :----------------------------------- |
-| Deploy and Release    | `deploy.yml`                        | Push of any git tag                  | Lint, test, build, SVN deploy, GitHub release |
-| Validate PR Title     | `validate-pull-request-title.yml`   | PR opened/edited/synchronize/reopened | Enforce conventional commit titles   |
+| Workflow           | File                                | Trigger                                                    | Purpose                                             |
+| :----------------- | :---------------------------------- | :--------------------------------------------------------- | :-------------------------------------------------- |
+| Deploy and Release | `deploy.yml`                        | Push of any git tag; `workflow_dispatch` (dry-run testing) | Lint, test, build, SVN deploy, GitHub release       |
+| Validate PR Title  | `validate-pull-request-title.yml`   | PR opened, edited, synchronize, or reopened                | Enforce conventional commit format on PR titles     |
 
 ## Pipeline Overview
 
@@ -15,59 +15,105 @@ This document describes all CI/CD workflows in `.github/workflows/`.
 sequenceDiagram
     participant Dev as Developer
     participant GH as GitHub
-    participant CI as deploy.yml
+    participant LA as lint-and-test job
+    participant DJ as deploy job
     participant SVN as WordPress.org SVN
     participant GHR as GitHub Releases
 
-    Dev->>GH: Push git tag (e.g. v2.4)
-    GH->>CI: Trigger deploy.yml
-    CI->>CI: Setup Node 16 + yarn install
-    CI->>CI: ESLint check
-    CI->>CI: Setup PHP 7.4 + composer install
-    CI->>CI: PHPCS check
-    CI->>CI: Unit tests (Pest)
-    CI->>CI: yarn build:production
-    CI->>CI: composer install --no-dev
-    CI->>CI: rsync → ./tmp/
-    CI->>SVN: 10up/action-wordpress-plugin-deploy (trunk + tag + zip)
-    CI->>GHR: Create GitHub release with .zip artifact
+    Dev->>GH: Push git tag (e.g. 2.6.1)
+    GH->>LA: Trigger deploy.yml
+    LA->>LA: Setup Node 18 + Corepack (Yarn 4) + yarn install --immutable
+    LA->>LA: yarn eslint
+    LA->>LA: Setup PHP 7.4 + composer install --no-interaction
+    LA->>LA: composer phpcs
+    LA->>LA: composer test
+    LA->>DJ: lint-and-test passed (needs:)
+    DJ->>DJ: Setup Node 18 + Corepack + yarn install --immutable
+    DJ->>DJ: yarn build:production
+    DJ->>DJ: composer install --no-dev --optimize-autoloader
+    DJ->>SVN: 10up/action-wordpress-plugin-deploy@2.3.0 (trunk + tag + zip)
+    DJ->>GHR: softprops/action-gh-release@v2.2.1 (attach .zip)
 ```
 
 ## Workflow Details
 
 ### Deploy and Release (`deploy.yml`)
 
-**Trigger:** push of any git tag (`on: push: tags: ["*"]`)
+**Triggers:**
 
-**Runner:** `ubuntu-latest`
+| Event                               | Behavior                                                                    |
+| :---------------------------------- | :-------------------------------------------------------------------------- |
+| Push of any git tag                 | Full pipeline: lint/test, build, SVN deploy, GitHub release                 |
+| `workflow_dispatch` (dry_run=true)  | Full pipeline; no SVN commit, no GitHub release                             |
+| `workflow_dispatch` (dry_run=false) | Lint/test and build only; deploy step is skipped (no tag ref available)     |
 
-**Steps:**
+**Inputs (`workflow_dispatch` only):**
 
-| Step                         | Tool / Command                                                | Notes                                              |
-| :--------------------------- | :------------------------------------------------------------ | :------------------------------------------------- |
-| Checkout code                | `actions/checkout@v2`                                         | Shallow clone (default, `fetch-depth: 1`)          |
-| Setup Node.js                | `actions/setup-node@v2` — Node 16                            | See [Improvements #2](improvements.md)             |
-| Install Node dependencies    | `yarn install`                                                | No `--frozen-lockfile` — see [#9](improvements.md) |
-| ESLint check                 | `yarn eslint`                                                 | Lints `assets/js/`                                 |
-| Setup PHP                    | `shivammathur/setup-php@v2` — PHP 7.4                        | See [Improvements #3](improvements.md)             |
-| Install Composer deps        | `composer install`                                            | Includes dev dependencies for tests                |
-| PHPCS check                  | `composer run phpcs`                                          | WordPress Coding Standards                         |
-| Unit tests                   | `vendor/bin/pest`                                             | See [Improvements #10](improvements.md)            |
-| Build                        | `yarn build:production` + `composer install --no-dev` + `rsync` to `./tmp/` | Produces clean release artifact       |
-| WordPress Plugin Deploy      | `10up/action-wordpress-plugin-deploy@stable`                  | SVN deploy to `trunk/` + `tags/<version>/` + zip  |
-| Create GitHub release        | `softprops/action-gh-release@v1`                              | Attaches `.zip` to the GitHub release              |
+| Input     | Type    | Required | Default | Description                                            |
+| :-------- | :------ | :------- | :------ | :----------------------------------------------------- |
+| `dry_run` | boolean | No       | `true`  | Skip SVN commit; run deploy step in no-op mode         |
+| `version` | string  | Yes      | —       | Version string (e.g. `2.6.1`); passed to the 10up action |
+
+**Permissions:**
+
+| Permission | Level   | Applied to                                      |
+| :--------- | :------ | :---------------------------------------------- |
+| `contents` | `read`  | Workflow-level default                          |
+| `contents` | `write` | `deploy` job only (required for GitHub release) |
+
+**Runner:** `ubuntu-latest` (both jobs)
+
+---
+
+#### Job: `lint-and-test`
+
+| Step                          | Tool / Command                                    | Notes                                                       |
+| :---------------------------- | :------------------------------------------------ | :---------------------------------------------------------- |
+| Checkout code                 | `actions/checkout@v4`                             |                                                             |
+| Setup Node.js                 | `actions/setup-node@v4` — Node 18                 | Matches local Volta pin                                     |
+| Enable Corepack               | `corepack enable`                                 | Activates Yarn 4 (from `package.json` `packageManager` field) |
+| Install Node dependencies     | `yarn install --immutable`                        | Fails if lockfile is out of sync                            |
+| Run JS lint                   | `yarn eslint`                                     | Lints `assets/js/`                                          |
+| Setup PHP                     | `shivammathur/setup-php@2.37.0` — PHP 7.4         |                                                             |
+| Install Composer dependencies | `composer install --no-interaction --prefer-dist` | Includes dev tools for PHPCS and tests                      |
+| Run PHPCS                     | `composer phpcs`                                  | WordPress Coding Standards                                  |
+| Run PHP unit tests            | `composer test`                                   | Runs Pest via composer script                               |
+
+#### Job: `deploy`
+
+Requires `lint-and-test` to pass (`needs: lint-and-test`).
+
+| Step                             | Tool / Command                                  | Condition / Notes                                                              |
+| :------------------------------- | :---------------------------------------------- | :----------------------------------------------------------------------------- |
+| Checkout code                    | `actions/checkout@v4`                           |                                                                                |
+| Setup Node.js                    | `actions/setup-node@v4` — Node 18               |                                                                                |
+| Enable Corepack                  | `corepack enable`                               | Activates Yarn 4                                                               |
+| Install Node dependencies        | `yarn install --immutable`                      |                                                                                |
+| Build assets                     | `yarn build:production`                         |                                                                                |
+| Setup PHP                        | `shivammathur/setup-php@2.37.0` — PHP 7.4       |                                                                                |
+| Install Composer (production)    | `composer install --no-dev --optimize-autoloader` |                                                                              |
+| WordPress Plugin Deploy          | `10up/action-wordpress-plugin-deploy@2.3.0`     | Runs only on tag push or `dry_run=true`; generates `.zip` (`generate-zip: true`) |
+| Create GitHub Release            | `softprops/action-gh-release@v2.2.1`            | Runs only on tag push with `dry_run=false`; attaches `.zip`                    |
 
 **Secrets required:**
 
-| Secret          | Used by                              | Purpose                          |
-| :-------------- | :----------------------------------- | :------------------------------- |
-| `SVN_USERNAME`  | `10up/action-wordpress-plugin-deploy` | WordPress.org SVN authentication |
-| `SVN_PASSWORD`  | `10up/action-wordpress-plugin-deploy` | WordPress.org SVN authentication |
-| `GITHUB_TOKEN`  | `softprops/action-gh-release`        | Create GitHub release (built-in) |
+| Secret         | Used by                               | Purpose                          |
+| :------------- | :------------------------------------ | :------------------------------- |
+| `SVN_USERNAME` | `10up/action-wordpress-plugin-deploy` | WordPress.org SVN authentication |
+| `SVN_PASSWORD` | `10up/action-wordpress-plugin-deploy` | WordPress.org SVN authentication |
+| `GITHUB_TOKEN` | `softprops/action-gh-release`         | Create GitHub release (built-in) |
 
 **SVN slug:** `axeptio-sdk-integration`
 
-**Artifact:** `axeptio-wordpress-plugin.zip` — attached to the GitHub release.
+**Asset directory:** `release-assets/` is published to SVN `assets/`.
+
+**Artifact:** `.zip` generated by the 10up action; attached to the GitHub release.
+
+> **Note:** `.distignore` controls which files are excluded from the SVN package in this CI workflow.
+> `exclusions.txt` serves the same purpose for the manual `task release` Taskfile command.
+> Both files must be kept in sync until one is retired. See [Improvements](improvements.md).
+
+---
 
 ### Validate PR Title (`validate-pull-request-title.yml`)
 
@@ -93,11 +139,11 @@ Scope is **not required**. WIP PRs are **not allowed**.
 
 The following exist locally (via Taskfile or Docker) but are **not run in GitHub Actions**:
 
-| Tool       | Local command           | Reason absent from CI                  |
-| :--------- | :---------------------- | :------------------------------------- |
-| PHPStan    | `task php-stan`         | Not included in `deploy.yml`           |
-| Rector     | `composer rector`       | Not included in `deploy.yml`           |
-| Docker     | `task build`            | CI installs tools natively, no Docker  |
+| Tool    | Local command     | Reason absent from CI                 |
+| :------ | :---------------- | :------------------------------------ |
+| PHPStan | `task php-stan`   | Not included in `deploy.yml`          |
+| Rector  | `composer rector` | Not included in `deploy.yml`          |
+| Docker  | `task build`      | CI installs tools natively, no Docker |
 
 > **Note:** A legacy `.gitlab-ci.yml` file is still present in the repository.
 > It only ran PHPCS and ESLint and was used before the migration to GitHub Actions.

--- a/docs/deployment/workflows.md
+++ b/docs/deployment/workflows.md
@@ -1,0 +1,104 @@
+# GitHub Actions Workflows
+
+This document describes all CI/CD workflows in `.github/workflows/`.
+
+## Workflow Inventory
+
+| Workflow              | File                                | Trigger                              | Purpose                              |
+| :-------------------- | :---------------------------------- | :----------------------------------- | :----------------------------------- |
+| Deploy and Release    | `deploy.yml`                        | Push of any git tag                  | Lint, test, build, SVN deploy, GitHub release |
+| Validate PR Title     | `validate-pull-request-title.yml`   | PR opened/edited/synchronize/reopened | Enforce conventional commit titles   |
+
+## Pipeline Overview
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant GH as GitHub
+    participant CI as deploy.yml
+    participant SVN as WordPress.org SVN
+    participant GHR as GitHub Releases
+
+    Dev->>GH: Push git tag (e.g. v2.4)
+    GH->>CI: Trigger deploy.yml
+    CI->>CI: Setup Node 16 + yarn install
+    CI->>CI: ESLint check
+    CI->>CI: Setup PHP 7.4 + composer install
+    CI->>CI: PHPCS check
+    CI->>CI: Unit tests (Pest)
+    CI->>CI: yarn build:production
+    CI->>CI: composer install --no-dev
+    CI->>CI: rsync → ./tmp/
+    CI->>SVN: 10up/action-wordpress-plugin-deploy (trunk + tag + zip)
+    CI->>GHR: Create GitHub release with .zip artifact
+```
+
+## Workflow Details
+
+### Deploy and Release (`deploy.yml`)
+
+**Trigger:** push of any git tag (`on: push: tags: ["*"]`)
+
+**Runner:** `ubuntu-latest`
+
+**Steps:**
+
+| Step                         | Tool / Command                                                | Notes                                          |
+| :--------------------------- | :------------------------------------------------------------ | :--------------------------------------------- |
+| Checkout code                | `actions/checkout@v2`                                         | Full history                                   |
+| Setup Node.js                | `actions/setup-node@v2` — Node 16                            | See [Improvements #2](improvements.md)         |
+| Install Node dependencies    | `yarn install`                                                | No `--frozen-lockfile` — see [#9](improvements.md) |
+| ESLint check                 | `yarn eslint`                                                 | Lints `assets/js/`                             |
+| Setup PHP                    | `shivammathur/setup-php@v2` — PHP 7.4                        | See [Improvements #3](improvements.md)         |
+| Install Composer deps        | `composer install`                                            | Includes dev dependencies for tests            |
+| PHPCS check                  | `composer run phpcs`                                          | WordPress Coding Standards                     |
+| Unit tests                   | `vendor/bin/pest`                                             | See [Improvements #10](improvements.md)        |
+| Build                        | `yarn build:production` + `composer install --no-dev` + `rsync` to `./tmp/` | Produces clean release artifact   |
+| WordPress Plugin Deploy      | `10up/action-wordpress-plugin-deploy@stable`                  | SVN deploy to `trunk/` + `tags/<version>/` + zip generation |
+| Create GitHub release        | `softprops/action-gh-release@v1`                              | Attaches `.zip` to the GitHub release          |
+
+**Secrets required:**
+
+| Secret          | Used by                              | Purpose                          |
+| :-------------- | :----------------------------------- | :------------------------------- |
+| `SVN_USERNAME`  | `10up/action-wordpress-plugin-deploy` | WordPress.org SVN authentication |
+| `SVN_PASSWORD`  | `10up/action-wordpress-plugin-deploy` | WordPress.org SVN authentication |
+| `GITHUB_TOKEN`  | `softprops/action-gh-release`        | Create GitHub release (built-in) |
+
+**SVN slug:** `axeptio-sdk-integration`
+
+**Artifact:** `axeptio-wordpress-plugin.zip` — attached to the GitHub release.
+
+### Validate PR Title (`validate-pull-request-title.yml`)
+
+**Trigger:** PR `opened`, `edited`, `synchronize`, `reopened`
+
+**Permissions:** `pull-requests: read`
+
+Uses `amannn/action-semantic-pull-request@v5` to enforce conventional commit format on PR titles.
+
+**Allowed types:**
+
+| Type       | Type       | Type       |
+| :--------- | :--------- | :--------- |
+| `build`    | `feat`     | `release`  |
+| `chore`    | `fix`      | `revert`   |
+| `ci`       | `hotfix`   | `style`    |
+| `docs`     | `perf`     | `test`     |
+|            | `refactor` |            |
+
+Scope is **not required**. WIP PRs are **not allowed**.
+
+## What Is NOT in CI
+
+The following exist locally (via Taskfile or Docker) but are **not run in GitHub Actions**:
+
+| Tool       | Local command           | Reason absent from CI                  |
+| :--------- | :---------------------- | :------------------------------------- |
+| PHPStan    | `task php-stan`         | Not included in `deploy.yml`           |
+| Rector     | `composer rector`       | Not included in `deploy.yml`           |
+| Docker     | `task build`            | CI installs tools natively, no Docker  |
+
+> **Note:** A legacy `.gitlab-ci.yml` file is still present in the repository.
+> It only ran PHPCS and ESLint and was used before the migration to GitHub Actions.
+> It is no longer active and should be removed. See [Improvements #5](improvements.md).

--- a/exclusions.txt
+++ b/exclusions.txt
@@ -5,6 +5,7 @@ node_modules/
 release-assets/
 releases/
 tmp/
+docs/
 composer.lock
 .dockerignore
 Dockerfile


### PR DESCRIPTION
## Summary

- Add comprehensive deployment documentation in `docs/deployment/` covering GitHub Actions workflows, release process, environments, and rollback strategy
- Add `.markdownlint.json` configuration for documentation linting
- Flag 15 improvement findings (2 critical, 4 high, 6 medium, 3 low) in a dedicated improvements doc

## Documentation files

| File                              | Content                                                     |
| :-------------------------------- | :---------------------------------------------------------- |
| `docs/deployment/README.md`       | Table of contents                                           |
| `docs/deployment/workflows.md`    | 2 GitHub Actions workflows with mermaid sequence diagram    |
| `docs/deployment/environments.md` | Local dev setup, WordPress.org SVN release process, rollback |
| `docs/deployment/improvements.md` | 15 flagged issues and recommendations                       |

> **Note:** Unlike the Shopify plugin, the WordPress plugin has no cloud infrastructure (no AWS, Terraform, ECS).
> It is distributed via WordPress.org SVN. There is no `infrastructure.md`.

## Linear issue

[ENG-11052](https://linear.app/axeptio/issue/ENG-11052/review-and-document-deployment-workflow-for-wordpress-plugin)

## Test plan

- [x] Verify markdown files render correctly on GitHub
- [x] Verify mermaid diagrams render in GitHub preview
- [ ] Review accuracy of workflow descriptions against actual `.github/workflows/` files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the WordPress plugin deployment workflow (GitHub Actions, local dev, WordPress.org release, rollback). Added markdownlint config, excluded docs/ from releases, and captured 15 improvement items — addresses ENG-11052.

- **New Features**
  - docs/deployment: README, workflows (2 GHA workflows with diagrams), environments (local + WordPress.org), improvements (15 items).
  - Added .markdownlint.json (disable MD013 for tables, MD060).
  - Updated exclusions.txt to exclude docs/ and recorded as a fixed finding.

- **Bug Fixes**
  - Corrected php-stan task in docs to “composer run run-stan”.
  - Clarified checkout step uses a shallow clone by default.

<sup>Written for commit c4f324f99573fe5eead53fdc6a8d1c18ff97a803. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

