### PR TITLE
fix: filter vendors without consent requirements from recommended settings

### DIFF
--- a/includes/classes/models/class-recommended-plugin-settings.php
+++ b/includes/classes/models/class-recommended-plugin-settings.php
@@ -92,6 +92,9 @@ class Recommended_Plugin_Settings {
 			if ( self::has_hooks( $plugin_item ) ) {
 				$plugin_name = $plugin_item['data']['name'];
 				foreach ( $plugin_item['data']['hooks'] as $hook ) {
+					if ( empty( $hook['consentRequirements'] ) ) {
+						continue;
+					}
 					self::process_hook( $results, $plugin_name, $hook );
 				}
 			}


### PR DESCRIPTION
**Problem**                                                         
                                                                                                                                                                                  
  The plugin was displaying the "This extension is subject to consent" badge for plugins like Contact Form 7, even though consent is not required for them.                       
   
  The root cause is that the Axeptio API (/v1/vendors/plugin) returns vendors that have hooks defined but no consentRequirements field on those hooks — meaning consent is not    
  needed. However, the plugin was only checking whether hooks existed (has_hooks()), without verifying if any of them actually require consent.
                                                                                                                                                                                  
**Fix**                                                             

  In Recommended_Plugin_Settings::process_plugin_items(), we now skip hooks that don't have a consentRequirements field set. If none of a vendor's hooks require consent, the     
  vendor won't appear in recommended settings, and the badge won't be shown.
                                                                                                                                                                                  
**How it was verified**                                             

  - Checked the API response: Contact Form 7 has hooks with no consentRequirements field and __enable: false                                                                      
  - Other vendors (YouTube Embed Plus, WP Google Maps, etc.) correctly have "consentRequirements": "required" on their hooks
  - After the fix, only vendors with explicit consent requirements will display the badge                                                                                         
                                                                                                                                                                                  
**Note**: 

The transient cache (axeptio/recommanded_plugin_settings) has a 24h TTL — it may need to be flushed for the fix to take effect immediately.          