### PR TITLE
ci: use GitHub variable for demo server IP

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   DEMO_DOMAIN: wordpress-qa.axept.io
-  DEMO_IP: 52.17.109.20
+  DEMO_IP: ${{ vars.DEMO_IP }}
   PLUGIN_SLUG: axeptio-sdk-integration
 
 jobs:

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   DEMO_DOMAIN: wordpress-qa.axept.io
-  DEMO_IP: 63.34.106.0
+  DEMO_IP: 52.17.109.20
   PLUGIN_SLUG: axeptio-sdk-integration
 
 jobs:


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `DEMO_IP` in the deploy workflow with the GitHub Actions variable `vars.DEMO_IP`
- The server IP changed from `63.34.106.0` to `52.17.109.20`, which caused deploy failures (connection timeout on port 443)

## Why
The demo server IP is dynamic (AWS) and was hardcoded in the workflow, requiring a code change + PR for every IP update. Using `vars.DEMO_IP` allows updating the IP directly in **Settings > Secrets and variables > Actions > Variables** without touching the codebase.

The variable `DEMO_IP` has already been created on the repo with the current value `52.17.109.20`.

## Test plan
- [x] Merge and verify the deploy workflow runs successfully on `develop`
- [ ] Confirm https://wordpress-qa.axept.io responds after deployment