### PR TITLE
ci: add release automation caller workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,22 @@
+name: Auto-Release
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: auto-release-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  auto-release:
+    uses: axeptio/tech-scripts/.github/workflows/auto-release.yml@auto-release-v0.0.1
+    with:
+      target_branch: master
+      source_branch: develop
+    secrets:
+      BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+      BOT_GPG_PRIVATE_KEY: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+      BOT_EMAIL: ${{ secrets.BOT_EMAIL }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,21 @@
+name: Create Release PR
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'  # Every Monday at 08:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: create-release-pr-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  create-release-pr:
+    uses: axeptio/tech-scripts/.github/workflows/create-release-pr.yml@create-release-pr-v0.0.1
+    with:
+      source_branch: develop
+      target_branch: master
+    secrets:
+      BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+      BOT_GPG_PRIVATE_KEY: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+      BOT_EMAIL: ${{ secrets.BOT_EMAIL }}


### PR DESCRIPTION
## Summary

Linear: ENG-12610
Spec: https://linear.app/axeptio/document/release-automation-spec-auto-releaseyml-and-create-release-pryml-764aff34ad43

Source branch: `develop` → Target branch: `master`

## Files added

- `.github/workflows/create-release-pr.yml` — caller workflow pinned to `create-release-pr-v0.0.1`; runs every Monday at 08:00 UTC (+ manual dispatch) to open a release PR from `develop` → `master`
- `.github/workflows/auto-release.yml` — caller workflow pinned to `auto-release-v0.0.1`; triggers on push to `master` to cut the GitHub release and update `develop`
- `.github/release-automation-enabled` — gate file added; automation active immediately after merge

## npm publish

No npm package — `has_npm_package: false`. The `auto-release` workflow is called without npm publish.

## Test plan

- [ ] Verify `create-release-pr` workflow runs on schedule and via `workflow_dispatch`
- [ ] Verify `auto-release` workflow triggers on merge to `master`
- [ ] Confirm secrets (`BOT_GITHUB_TOKEN`, `BOT_GPG_PRIVATE_KEY`, `BOT_EMAIL`) are configured in repo settings